### PR TITLE
fix #9 build break for './gradlew publishToMavenLocal'  on macOS

### DIFF
--- a/packages/cinterop/build.gradle.kts
+++ b/packages/cinterop/build.gradle.kts
@@ -877,4 +877,19 @@ afterEvaluate {
     tasks.named("jvmSourcesJar") {
         dependsOn("generateSdkVersionConstant")
     }
+    tasks.named("iosArm64SourcesJar") {
+        dependsOn("generateSdkVersionConstant")
+    }
+    tasks.named("iosSimulatorArm64SourcesJar") {
+        dependsOn("generateSdkVersionConstant")
+    }
+    tasks.named("iosX64SourcesJar") {
+        dependsOn("generateSdkVersionConstant")
+    }
+    tasks.named("macosArm64SourcesJar") {
+        dependsOn("generateSdkVersionConstant")
+    }
+    tasks.named("macosX64SourcesJar") {
+        dependsOn("generateSdkVersionConstant")
+    }
 }


### PR DESCRIPTION
This PR fixes the issue #9

Seel also https://github.com/realm/realm-kotlin/issues/1857#issuecomment-2705896749
